### PR TITLE
go/cmd/aoc: remove unnecessarily verbose types

### DIFF
--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -19,10 +19,8 @@ type Day struct {
 	One Solution
 	Two Solution
 }
-type Years map[uint]Days
-type Days map[uint]Day
 
-var okYears Years
+var solutions map[uint]map[uint]Day
 
 func imain() (exitCode int) {
 	flag.Parse()


### PR DESCRIPTION
I will not do anything specific with these types anyway, so I might as well just have a simple variable with a little more complex type.