### PR TITLE
go: add solution for year 2015, day 03

### DIFF
--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -26,6 +26,7 @@ var solutions = map[uint]map[uint]Day{
 	2015: map[uint]Day{
 		1: {One: year2015.Day01One, Two: year2015.Day01Two},
 		2: {One: year2015.Day02One, Two: year2015.Day02Two},
+		3: {One: year2015.Day03One},
 	},
 }
 

--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -26,7 +26,7 @@ var solutions = map[uint]map[uint]Day{
 	2015: map[uint]Day{
 		1: {One: year2015.Day01One, Two: year2015.Day01Two},
 		2: {One: year2015.Day02One, Two: year2015.Day02Two},
-		3: {One: year2015.Day03One},
+		3: {One: year2015.Day03One, Two: year2015.Day03Two},
 	},
 }
 

--- a/go/internal/geo/point.go
+++ b/go/internal/geo/point.go
@@ -1,0 +1,25 @@
+package geo
+
+type Point struct {
+	X, Y int
+}
+
+const (
+	North = iota
+	East
+	South
+	West
+)
+
+func (p *Point) Step(direction int) {
+	switch direction {
+	case North:
+		p.Y++
+	case East:
+		p.X++
+	case South:
+		p.Y--
+	case West:
+		p.X--
+	}
+}

--- a/go/internal/geo/point_test.go
+++ b/go/internal/geo/point_test.go
@@ -1,0 +1,29 @@
+package geo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoint_Step(t *testing.T) {
+	for _, tt := range []struct {
+		start Point
+		steps []int
+		end   Point
+	}{
+		{start: Point{X: 0, Y: 0}, steps: []int{North}, end: Point{X: 0, Y: 1}},
+		{start: Point{X: 0, Y: 0}, steps: []int{East}, end: Point{X: 1, Y: 0}},
+		{start: Point{X: 0, Y: 0}, steps: []int{South}, end: Point{X: 0, Y: -1}},
+		{start: Point{X: 0, Y: 0}, steps: []int{West}, end: Point{X: -1, Y: 0}},
+	} {
+		t.Run(fmt.Sprintf("start=%v,steps=%v", tt.start, tt.steps), func(t *testing.T) {
+			p := tt.start
+			for _, direction := range tt.steps {
+				p.Step(direction)
+			}
+			require.Equal(t, tt.end, p)
+		})
+	}
+}

--- a/go/internal/year2015/day03.go
+++ b/go/internal/year2015/day03.go
@@ -1,10 +1,46 @@
 package year2015
 
 import (
-	"errors"
+	"bufio"
+	"fmt"
 	"io"
+
+	"github.com/Saser/adventofcode/internal/geo"
 )
 
 func Day03One(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	return solveDay03(r, 1)
+}
+
+func solveDay03(r io.Reader, part int) (string, error) {
+	// The part number just so happens to be the same as the numbers of travelers:
+	// In part 1, there is 1 (Santa), and in part 2, there are 2 (Santa and Robo-Santa).
+	travelers := make([]geo.Point, part)
+	currentTraveler := 0
+	visited := map[geo.Point]struct{}{
+		geo.Point{X: 0, Y: 0}: struct{}{},
+	}
+
+	sc := bufio.NewScanner(r)
+	sc.Split(bufio.ScanRunes)
+	for sc.Scan() {
+		tok := sc.Text()
+		var direction int
+		switch tok {
+		case "^":
+			direction = geo.North
+		case ">":
+			direction = geo.East
+		case "v":
+			direction = geo.South
+		case "<":
+			direction = geo.West
+		default:
+			return "", fmt.Errorf("invalid direction: %s", tok)
+		}
+		travelers[currentTraveler].Step(direction)
+		visited[travelers[currentTraveler]] = struct{}{}
+		currentTraveler = (currentTraveler + 1) % len(travelers)
+	}
+	return fmt.Sprint(len(visited)), nil
 }

--- a/go/internal/year2015/day03.go
+++ b/go/internal/year2015/day03.go
@@ -1,0 +1,10 @@
+package year2015
+
+import (
+	"errors"
+	"io"
+)
+
+func Day03One(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
+}

--- a/go/internal/year2015/day03.go
+++ b/go/internal/year2015/day03.go
@@ -12,6 +12,10 @@ func Day03One(r io.Reader) (string, error) {
 	return solveDay03(r, 1)
 }
 
+func Day03Two(r io.Reader) (string, error) {
+	return solveDay03(r, 2)
+}
+
 func solveDay03(r io.Reader, part int) (string, error) {
 	// The part number just so happens to be the same as the numbers of travelers:
 	// In part 1, there is 1 (Santa), and in part 2, there are 2 (Santa and Robo-Santa).

--- a/go/internal/year2015/day03_test.go
+++ b/go/internal/year2015/day03_test.go
@@ -1,0 +1,27 @@
+package year2015
+
+import (
+	"testing"
+
+	"github.com/Saser/adventofcode/internal/testcase"
+)
+
+func TestDay03(t *testing.T) {
+	t.Run("part1", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", ">", "2"),
+			testcase.FromString("example2", "^>v<", "4"),
+			testcase.FromString("example3", "^v^v^v^v^v", "2"),
+			testcase.FromInputFile(t, 2015, 3, "2572"),
+		} {
+			testcase.Run(t, tc, Day03One)
+		}
+	})
+}
+
+func BenchmarkDay03(b *testing.B) {
+	tc := testcase.FromInputFile(b, 2015, 3, "")
+	b.Run("part1", func(b *testing.B) {
+		testcase.Bench(b, tc, Day03One)
+	})
+}

--- a/go/internal/year2015/day03_test.go
+++ b/go/internal/year2015/day03_test.go
@@ -17,11 +17,24 @@ func TestDay03(t *testing.T) {
 			testcase.Run(t, tc, Day03One)
 		}
 	})
+	t.Run("part2", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", "^v", "3"),
+			testcase.FromString("example2", "^>v<", "3"),
+			testcase.FromString("example3", "^v^v^v^v^v", "11"),
+			testcase.FromInputFile(t, 2015, 3, "2631"),
+		} {
+			testcase.Run(t, tc, Day03Two)
+		}
+	})
 }
 
 func BenchmarkDay03(b *testing.B) {
 	tc := testcase.FromInputFile(b, 2015, 3, "")
 	b.Run("part1", func(b *testing.B) {
 		testcase.Bench(b, tc, Day03One)
+	})
+	b.Run("part2", func(b *testing.B) {
+		testcase.Bench(b, tc, Day03Two)
 	})
 }


### PR DESCRIPTION
This puzzle was fairly simple: just keep track of several discrete "travelers", and the points they have visited.

Benchmarks (`go test -bench=Day03 ./internal/year2015`):

| Part   | Benchmark     |
|--------|---------------|
| Part 1 | 1122131 ns/op |
| Part 2 | 1118239 ns/op |