### PR TITLE
go: add solution for year 2015, day 04

### DIFF
--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -27,6 +27,7 @@ var solutions = map[uint]map[uint]Day{
 		1: {One: year2015.Day01One, Two: year2015.Day01Two},
 		2: {One: year2015.Day02One, Two: year2015.Day02Two},
 		3: {One: year2015.Day03One, Two: year2015.Day03Two},
+		4: {One: year2015.Day04One},
 	},
 }
 

--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -27,7 +27,7 @@ var solutions = map[uint]map[uint]Day{
 		1: {One: year2015.Day01One, Two: year2015.Day01Two},
 		2: {One: year2015.Day02One, Two: year2015.Day02Two},
 		3: {One: year2015.Day03One, Two: year2015.Day03Two},
-		4: {One: year2015.Day04One},
+		4: {One: year2015.Day04One, Two: year2015.Day04Two},
 	},
 }
 

--- a/go/internal/year2015/day04.go
+++ b/go/internal/year2015/day04.go
@@ -1,10 +1,32 @@
 package year2015
 
 import (
-	"errors"
+	"bufio"
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
 	"io"
 )
 
 func Day04One(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	return solveDay04(r, 0x00000fff)
+}
+
+func solveDay04(r io.Reader, limit uint32) (string, error) {
+	br := bufio.NewReader(r)
+	prefix, _, err := br.ReadLine()
+	if err != nil {
+		return "", fmt.Errorf("year 2015, day 04, part 1: %w", err)
+	}
+	i := 1
+	for {
+		s := fmt.Sprintf("%s%d", prefix, i)
+		sum := md5.Sum([]byte(s))
+		v := binary.BigEndian.Uint32(sum[:4])
+		if v <= limit {
+			break
+		}
+		i++
+	}
+	return fmt.Sprint(i), nil
 }

--- a/go/internal/year2015/day04.go
+++ b/go/internal/year2015/day04.go
@@ -12,6 +12,10 @@ func Day04One(r io.Reader) (string, error) {
 	return solveDay04(r, 0x00000fff)
 }
 
+func Day04Two(r io.Reader) (string, error) {
+	return solveDay04(r, 0x000000ff)
+}
+
 func solveDay04(r io.Reader, limit uint32) (string, error) {
 	br := bufio.NewReader(r)
 	prefix, _, err := br.ReadLine()

--- a/go/internal/year2015/day04.go
+++ b/go/internal/year2015/day04.go
@@ -1,0 +1,10 @@
+package year2015
+
+import (
+	"errors"
+	"io"
+)
+
+func Day04One(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
+}

--- a/go/internal/year2015/day04_test.go
+++ b/go/internal/year2015/day04_test.go
@@ -16,11 +16,21 @@ func TestDay04(t *testing.T) {
 			testcase.Run(t, tc, Day04One)
 		}
 	})
+	t.Run("part2", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromInputFile(t, 2015, 4, "9958218"),
+		} {
+			testcase.Run(t, tc, Day04Two)
+		}
+	})
 }
 
 func BenchmarkDay04(b *testing.B) {
 	tc := testcase.FromInputFile(b, 2015, 4, "")
 	b.Run("part1", func(b *testing.B) {
 		testcase.Bench(b, tc, Day04One)
+	})
+	b.Run("part2", func(b *testing.B) {
+		testcase.Bench(b, tc, Day04Two)
 	})
 }

--- a/go/internal/year2015/day04_test.go
+++ b/go/internal/year2015/day04_test.go
@@ -1,0 +1,25 @@
+package year2015
+
+import (
+	"testing"
+
+	"github.com/Saser/adventofcode/internal/testcase"
+)
+
+func TestDay04(t *testing.T) {
+	t.Run("part1", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", "abcdef", "609043"),
+			testcase.FromString("example2", "pqrstuv", "1048970"),
+		} {
+			testcase.Run(t, tc, Day04One)
+		}
+	})
+}
+
+func BenchmarkDay04(b *testing.B) {
+	tc := testcase.FromInputFile(b, 2015, 4, "")
+	b.Run("part1", func(b *testing.B) {
+		testcase.Bench(b, tc, Day04One)
+	})
+}

--- a/go/internal/year2015/day04_test.go
+++ b/go/internal/year2015/day04_test.go
@@ -11,6 +11,7 @@ func TestDay04(t *testing.T) {
 		for _, tc := range []testcase.TestCase{
 			testcase.FromString("example1", "abcdef", "609043"),
 			testcase.FromString("example2", "pqrstuv", "1048970"),
+			testcase.FromInputFile(t, 2015, 4, "346386"),
 		} {
 			testcase.Run(t, tc, Day04One)
 		}


### PR DESCRIPTION
This was a slow one, due to the fact that the solution can only be brute-forced (as far as I am aware). I tried to make it at least not excruciatingly slow, but I can't be arsed to do a lot of micro-optimizations.

Bencmarks (`go test -bench=Day04 -benchtime=1m ./internal/year2015`):

| Part   | Benchmark                      |
|--------|--------------------------------|
| Part 1 | 169096163 ns/op (~169 ms/op)   |
| Part 2 | 4816739203 ns/op (~4816 ms/op) |