### PR TITLE
go: add solution for year 2015, day 05

### DIFF
--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -28,7 +28,7 @@ var solutions = map[uint]map[uint]Day{
 		2: {One: year2015.Day02One, Two: year2015.Day02Two},
 		3: {One: year2015.Day03One, Two: year2015.Day03Two},
 		4: {One: year2015.Day04One, Two: year2015.Day04Two},
-		5: {One: year2015.Day05One},
+		5: {One: year2015.Day05One, Two: year2015.Day05Two},
 	},
 }
 

--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -28,6 +28,7 @@ var solutions = map[uint]map[uint]Day{
 		2: {One: year2015.Day02One, Two: year2015.Day02Two},
 		3: {One: year2015.Day03One, Two: year2015.Day03Two},
 		4: {One: year2015.Day04One, Two: year2015.Day04Two},
+		5: {One: year2015.Day05One},
 	},
 }
 

--- a/go/internal/year2015/day05.go
+++ b/go/internal/year2015/day05.go
@@ -1,0 +1,10 @@
+package year2015
+
+import (
+	"errors"
+	"io"
+)
+
+func Day05One(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
+}

--- a/go/internal/year2015/day05.go
+++ b/go/internal/year2015/day05.go
@@ -1,6 +1,7 @@
 package year2015
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,6 +19,10 @@ func Day05One(r io.Reader) (string, error) {
 		noBadPairs,
 	}
 	return solveDay05(lines, conditions), nil
+}
+
+func Day05Two(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
 }
 
 func parseDay05(r io.Reader) ([]string, error) {

--- a/go/internal/year2015/day05.go
+++ b/go/internal/year2015/day05.go
@@ -1,7 +1,6 @@
 package year2015
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -22,7 +21,15 @@ func Day05One(r io.Reader) (string, error) {
 }
 
 func Day05Two(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	lines, err := parseDay05(r)
+	if err != nil {
+		return "", fmt.Errorf("year 2015, day 05, part 2: %w", err)
+	}
+	conditions := []day05Condition{
+		twicePair,
+		letterTwiceSpaced,
+	}
+	return solveDay05(lines, conditions), nil
 }
 
 func parseDay05(r io.Reader) ([]string, error) {
@@ -80,4 +87,22 @@ func noBadPairs(s string) bool {
 		}
 	}
 	return true
+}
+
+func twicePair(s string) bool {
+	for i := 0; i < len(s)-2; i++ {
+		if strings.Contains(s[i+2:], s[i:i+2]) {
+			return true
+		}
+	}
+	return false
+}
+
+func letterTwiceSpaced(s string) bool {
+	for i := 0; i < len(s)-2; i++ {
+		if s[i] == s[i+2] {
+			return true
+		}
+	}
+	return false
 }

--- a/go/internal/year2015/day05.go
+++ b/go/internal/year2015/day05.go
@@ -1,10 +1,78 @@
 package year2015
 
 import (
-	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"strings"
 )
 
 func Day05One(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	lines, err := parseDay05(r)
+	if err != nil {
+		return "", fmt.Errorf("year 2015, day 05, part 1: %w", err)
+	}
+	conditions := []day05Condition{
+		threeVowels,
+		letterTwice,
+		noBadPairs,
+	}
+	return solveDay05(lines, conditions), nil
+}
+
+func parseDay05(r io.Reader) ([]string, error) {
+	bytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	lines := strings.Split(string(bytes), "\n")
+	return lines, nil
+}
+
+func solveDay05(lines []string, conditions []day05Condition) string {
+	count := 0
+outer:
+	for _, line := range lines {
+		for _, cond := range conditions {
+			if !cond(line) {
+				continue outer
+			}
+		}
+		count++
+	}
+	return fmt.Sprint(count)
+}
+
+type day05Condition func(string) bool
+
+func threeVowels(s string) (b bool) {
+	count := 0
+	for _, r := range s {
+		switch r {
+		case 'a', 'e', 'i', 'o', 'u':
+			count++
+			if count >= 3 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func letterTwice(s string) bool {
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == s[i+1] {
+			return true
+		}
+	}
+	return false
+}
+
+func noBadPairs(s string) bool {
+	for _, pair := range []string{"ab", "cd", "pq", "xy"} {
+		if strings.Contains(s, pair) {
+			return false
+		}
+	}
+	return true
 }

--- a/go/internal/year2015/day05_test.go
+++ b/go/internal/year2015/day05_test.go
@@ -25,6 +25,7 @@ func TestDay05(t *testing.T) {
 			testcase.FromString("example2", "xxyxx", "1"),
 			testcase.FromString("example3", "uurcxstgmygtbstg", "0"),
 			testcase.FromString("example4", "ieodomkazucvgmuy", "0"),
+			testcase.FromInputFile(t, 2015, 5, "55"),
 		} {
 			testcase.Run(t, tc, Day05Two)
 		}

--- a/go/internal/year2015/day05_test.go
+++ b/go/internal/year2015/day05_test.go
@@ -19,11 +19,24 @@ func TestDay05(t *testing.T) {
 			testcase.Run(t, tc, Day05One)
 		}
 	})
+	t.Run("part2", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", "qjhvhtzxzqqjkmpb", "1"),
+			testcase.FromString("example2", "xxyxx", "1"),
+			testcase.FromString("example3", "uurcxstgmygtbstg", "0"),
+			testcase.FromString("example4", "ieodomkazucvgmuy", "0"),
+		} {
+			testcase.Run(t, tc, Day05Two)
+		}
+	})
 }
 
 func BenchmarkDay05(b *testing.B) {
 	tc := testcase.FromInputFile(b, 2015, 5, "")
 	b.Run("part1", func(b *testing.B) {
 		testcase.Bench(b, tc, Day05One)
+	})
+	b.Run("part2", func(b *testing.B) {
+		testcase.Bench(b, tc, Day05Two)
 	})
 }

--- a/go/internal/year2015/day05_test.go
+++ b/go/internal/year2015/day05_test.go
@@ -1,0 +1,29 @@
+package year2015
+
+import (
+	"testing"
+
+	"github.com/Saser/adventofcode/internal/testcase"
+)
+
+func TestDay05(t *testing.T) {
+	t.Run("part1", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", "ugknbfddgicrmopn", "1"),
+			testcase.FromString("example2", "aaa", "1"),
+			testcase.FromString("example3", "jchzalrnumimnmhp", "0"),
+			testcase.FromString("example4", "haegwjzuvuyypxyu", "0"),
+			testcase.FromString("example5", "dvszwmarrgswjxmb", "0"),
+			testcase.FromInputFile(t, 2015, 5, "255"),
+		} {
+			testcase.Run(t, tc, Day05One)
+		}
+	})
+}
+
+func BenchmarkDay05(b *testing.B) {
+	tc := testcase.FromInputFile(b, 2015, 5, "")
+	b.Run("part1", func(b *testing.B) {
+		testcase.Bench(b, tc, Day05One)
+	})
+}


### PR DESCRIPTION
I found the solution of specifying a list of conditions to be a fairly easy way to solve this problem. It runs fast enough, too.

Benchmarks (`go test -bench=Day05 ./internal/year2015`):

| Part   | Benchmark                   |
|--------|-----------------------------|
| Part 1 | 159984 ns/op (~0.160 ms/op) |
| Part 2 | 218056 ns/op (~0.218 ms/op) |