### PR TITLE
go: add solution for year 2015, day 06

### DIFF
--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -29,7 +29,7 @@ var solutions = map[uint]map[uint]Day{
 		3: {One: year2015.Day03One, Two: year2015.Day03Two},
 		4: {One: year2015.Day04One, Two: year2015.Day04Two},
 		5: {One: year2015.Day05One, Two: year2015.Day05Two},
-		6: {One: year2015.Day06One},
+		6: {One: year2015.Day06One, Two: year2015.Day06Two},
 	},
 }
 

--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -29,6 +29,7 @@ var solutions = map[uint]map[uint]Day{
 		3: {One: year2015.Day03One, Two: year2015.Day03Two},
 		4: {One: year2015.Day04One, Two: year2015.Day04Two},
 		5: {One: year2015.Day05One, Two: year2015.Day05Two},
+		6: {One: year2015.Day06One},
 	},
 }
 

--- a/go/internal/year2015/day06.go
+++ b/go/internal/year2015/day06.go
@@ -1,0 +1,10 @@
+package year2015
+
+import (
+	"errors"
+	"io"
+)
+
+func Day06One(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
+}

--- a/go/internal/year2015/day06.go
+++ b/go/internal/year2015/day06.go
@@ -1,10 +1,110 @@
 package year2015
 
 import (
-	"errors"
+	"bufio"
+	"fmt"
 	"io"
+	"math"
+	"regexp"
+	"strconv"
+
+	"github.com/Saser/adventofcode/internal/geo"
 )
 
 func Day06One(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	instructions, err := parseDay06(r)
+	if err != nil {
+		return "", fmt.Errorf("year 2015, day 06, part 1: %w", err)
+	}
+	grid := make([][]bool, 0, 1000)
+	for x := 0; x < 1000; x++ {
+		grid = append(grid, make([]bool, 1000))
+	}
+	for _, instruction := range instructions {
+		instruction.apply(grid)
+	}
+	count := 0
+	for _, row := range grid {
+		for _, light := range row {
+			if light {
+				count++
+			}
+		}
+	}
+	return fmt.Sprint(count), nil
+}
+
+type day06Operation func(bool) bool
+
+type day06Instruction struct {
+	start     geo.Point
+	end       geo.Point
+	operation day06Operation
+}
+
+func parseDay06(r io.Reader) ([]day06Instruction, error) {
+	sc := bufio.NewScanner(r)
+	sc.Split(bufio.ScanLines)
+	re, err := regexp.Compile(`(turn on|turn off|toggle) (\d{1,3}),(\d{1,3}) through (\d{1,3}),(\d{1,3})`)
+	if err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+	instructions := make([]day06Instruction, 0)
+	for sc.Scan() {
+		line := sc.Text()
+		matches := re.FindStringSubmatch(line)
+		var operation day06Operation
+		switch matches[1] {
+		case "turn on":
+			operation = turnOn
+		case "turn off":
+			operation = turnOff
+		case "toggle":
+			operation = toggle
+		}
+		startX, err := strconv.Atoi(matches[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse: %w", err)
+		}
+		startY, err := strconv.Atoi(matches[3])
+		if err != nil {
+			return nil, fmt.Errorf("parse: %w", err)
+		}
+		start := geo.Point{X: startX, Y: startY}
+		endX, err := strconv.Atoi(matches[4])
+		if err != nil {
+			return nil, fmt.Errorf("parse: %w", err)
+		}
+		endY, err := strconv.Atoi(matches[5])
+		if err != nil {
+			return nil, fmt.Errorf("parse: %w", err)
+		}
+		end := geo.Point{X: endX, Y: endY}
+		instructions = append(instructions, day06Instruction{start: start, end: end, operation: operation})
+	}
+	return instructions, nil
+}
+
+func (d *day06Instruction) apply(grid [][]bool) {
+	xMin := int(math.Min(float64(d.start.X), float64(d.end.X)))
+	xMax := int(math.Max(float64(d.start.X), float64(d.end.X)))
+	yMin := int(math.Min(float64(d.start.Y), float64(d.end.Y)))
+	yMax := int(math.Max(float64(d.start.Y), float64(d.end.Y)))
+	for x := xMin; x <= xMax; x++ {
+		for y := yMin; y <= yMax; y++ {
+			grid[x][y] = d.operation(grid[x][y])
+		}
+	}
+}
+
+func turnOn(_ bool) bool {
+	return true
+}
+
+func turnOff(_ bool) bool {
+	return false
+}
+
+func toggle(b bool) bool {
+	return !b
 }

--- a/go/internal/year2015/day06.go
+++ b/go/internal/year2015/day06.go
@@ -19,6 +19,14 @@ func Day06One(r io.Reader) (string, error) {
 	return solveDay06(instructions)
 }
 
+func Day06Two(r io.Reader) (string, error) {
+	instructions, err := parseDay06(r, 2)
+	if err != nil {
+		return "", fmt.Errorf("year 2015, day 06, part 1: %w", err)
+	}
+	return solveDay06(instructions)
+}
+
 func solveDay06(instructions []day06Instruction) (string, error) {
 	grid := make([][]int, 0, 1000)
 	for x := 0; x < 1000; x++ {
@@ -124,5 +132,23 @@ func toggle(i int) int {
 		return 1
 	} else {
 		return 0
+	}
+}
+
+func increaseBy(d int) day06Operation {
+	return func(i int) int {
+		return i + d
+	}
+}
+
+func decrease(i int) int {
+	return int(math.Max(0, float64(i-1)))
+}
+
+func decrease2(i int) int {
+	if i == 0 {
+		return 0
+	} else {
+		return i - 1
 	}
 }

--- a/go/internal/year2015/day06_test.go
+++ b/go/internal/year2015/day06_test.go
@@ -1,0 +1,26 @@
+package year2015
+
+import (
+	"testing"
+
+	"github.com/Saser/adventofcode/internal/testcase"
+)
+
+func TestDay06(t *testing.T) {
+	t.Run("part1", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", "turn on 0,0 through 999,999", "1000000"),
+			testcase.FromString("example2", "toggle 0,0 through 999,0", "1000"),
+			testcase.FromString("example3", "turn off 499,499 through 500,500", "0"),
+		} {
+			testcase.Run(t, tc, Day06One)
+		}
+	})
+}
+
+func BenchmarkDay06(b *testing.B) {
+	tc := testcase.FromInputFile(b, 2015, 6, "")
+	b.Run("part1", func(b *testing.B) {
+		testcase.Bench(b, tc, Day06One)
+	})
+}

--- a/go/internal/year2015/day06_test.go
+++ b/go/internal/year2015/day06_test.go
@@ -12,6 +12,7 @@ func TestDay06(t *testing.T) {
 			testcase.FromString("example1", "turn on 0,0 through 999,999", "1000000"),
 			testcase.FromString("example2", "toggle 0,0 through 999,0", "1000"),
 			testcase.FromString("example3", "turn off 499,499 through 500,500", "0"),
+			testcase.FromInputFile(t, 2015, 6, "569999"),
 		} {
 			testcase.Run(t, tc, Day06One)
 		}

--- a/go/internal/year2015/day06_test.go
+++ b/go/internal/year2015/day06_test.go
@@ -17,11 +17,23 @@ func TestDay06(t *testing.T) {
 			testcase.Run(t, tc, Day06One)
 		}
 	})
+	t.Run("part2", func(t *testing.T) {
+		for _, tc := range []testcase.TestCase{
+			testcase.FromString("example1", "turn on 0,0 through 0,0", "1"),
+			testcase.FromString("example2", "toggle 0,0 through 999,999", "2000000"),
+			testcase.FromInputFile(t, 2015, 6, "17836115"),
+		} {
+			testcase.Run(t, tc, Day06Two)
+		}
+	})
 }
 
 func BenchmarkDay06(b *testing.B) {
 	tc := testcase.FromInputFile(b, 2015, 6, "")
 	b.Run("part1", func(b *testing.B) {
 		testcase.Bench(b, tc, Day06One)
+	})
+	b.Run("part2", func(b *testing.B) {
+		testcase.Bench(b, tc, Day06Two)
 	})
 }


### PR DESCRIPTION
I am sure there must be a obvious, more efficient way of doing this than just keeping a large 2D slice in memory, but I haven't found it yet.