### PR TITLE
inputs: remove all days 26-31 in all years

### DIFF
--- a/inputs/2015/26
+++ b/inputs/2015/26
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2015/27
+++ b/inputs/2015/27
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2015/28
+++ b/inputs/2015/28
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2015/29
+++ b/inputs/2015/29
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2015/30
+++ b/inputs/2015/30
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2015/31
+++ b/inputs/2015/31
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2016/26
+++ b/inputs/2016/26
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2016/27
+++ b/inputs/2016/27
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2016/28
+++ b/inputs/2016/28
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2016/29
+++ b/inputs/2016/29
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2016/30
+++ b/inputs/2016/30
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2016/31
+++ b/inputs/2016/31
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2017/26
+++ b/inputs/2017/26
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2017/27
+++ b/inputs/2017/27
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2017/28
+++ b/inputs/2017/28
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2017/29
+++ b/inputs/2017/29
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2017/30
+++ b/inputs/2017/30
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2017/31
+++ b/inputs/2017/31
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2018/26
+++ b/inputs/2018/26
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2018/27
+++ b/inputs/2018/27
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2018/28
+++ b/inputs/2018/28
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2018/29
+++ b/inputs/2018/29
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2018/30
+++ b/inputs/2018/30
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.

--- a/inputs/2018/31
+++ b/inputs/2018/31
@@ -1,1 +1,0 @@
-Please don't repeatedly request this endpoint before it unlocks! The calendar countdown is synchronized with the server time; the link will be enabled on the calendar the instant this puzzle becomes available.


### PR DESCRIPTION
I apparently did not pay attention very much when running the script that downloaded my inputs, as I forgot that there are no more puzzles after day 25 in any of the years.