### PR TITLE
go: add solution for year 2015, day 12

### DIFF
--- a/go/cmd/aoc/main.go
+++ b/go/cmd/aoc/main.go
@@ -18,6 +18,7 @@ import (
 	year2015day09 "github.com/Saser/adventofcode/internal/year2015/day09"
 	year2015day10 "github.com/Saser/adventofcode/internal/year2015/day10"
 	year2015day11 "github.com/Saser/adventofcode/internal/year2015/day11"
+	year2015day12 "github.com/Saser/adventofcode/internal/year2015/day12"
 )
 
 var (
@@ -45,6 +46,7 @@ var solutions = map[uint]map[uint]Day{
 		9:  {One: year2015day09.Part1, Two: year2015day09.Part2},
 		10: {One: year2015day10.Part1, Two: year2015day10.Part2},
 		11: {One: year2015day11.Part1, Two: year2015day11.Part2},
+		12: {One: year2015day12.Part1, Two: year2015day12.Part2},
 	},
 }
 

--- a/go/internal/year2015/day12/day12.go
+++ b/go/internal/year2015/day12/day12.go
@@ -2,6 +2,7 @@ package day12
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -19,4 +20,8 @@ func Part1(r io.Reader) (string, error) {
 		}
 	}
 	return fmt.Sprint(sum), nil
+}
+
+func Part2(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
 }

--- a/go/internal/year2015/day12/day12.go
+++ b/go/internal/year2015/day12/day12.go
@@ -1,10 +1,22 @@
 package day12
 
 import (
-	"errors"
+	"encoding/json"
+	"fmt"
 	"io"
 )
 
 func Part1(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	decoder := json.NewDecoder(r)
+	var sum int64
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if v, ok := token.(float64); ok {
+			sum += int64(v)
+		}
+	}
+	return fmt.Sprint(sum), nil
 }

--- a/go/internal/year2015/day12/day12.go
+++ b/go/internal/year2015/day12/day12.go
@@ -2,9 +2,9 @@ package day12
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 )
 
 func Part1(r io.Reader) (string, error) {
@@ -23,5 +23,38 @@ func Part1(r io.Reader) (string, error) {
 }
 
 func Part2(r io.Reader) (string, error) {
-	return "", errors.New("not yet implemented")
+	var j interface{}
+	bytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("year 2015, day 12, part 2: %w", err)
+	}
+	if err := json.Unmarshal(bytes, &j); err != nil {
+		return "", fmt.Errorf("year 2015, day 12, part 2: %w", err)
+	}
+	return fmt.Sprint(sumJSON(j, 2)), nil
+}
+
+func sumJSON(j interface{}, part int) int {
+	switch v := j.(type) {
+	case float64:
+		return int(v)
+	case string:
+		return 0
+	case []interface{}:
+		sum := 0
+		for _, k := range v {
+			sum += sumJSON(k, part)
+		}
+		return sum
+	case map[string]interface{}:
+		sum := 0
+		for _, k := range v {
+			if s, ok := k.(string); ok && part == 2 && s == "red" {
+				return 0
+			}
+			sum += sumJSON(k, part)
+		}
+		return sum
+	}
+	panic(fmt.Sprintf("invalid JSON value: %v (%T)", j, j))
 }

--- a/go/internal/year2015/day12/day12.go
+++ b/go/internal/year2015/day12/day12.go
@@ -1,0 +1,10 @@
+package day12
+
+import (
+	"errors"
+	"io"
+)
+
+func Part1(r io.Reader) (string, error) {
+	return "", errors.New("not yet implemented")
+}

--- a/go/internal/year2015/day12/day12.go
+++ b/go/internal/year2015/day12/day12.go
@@ -8,21 +8,14 @@ import (
 )
 
 func Part1(r io.Reader) (string, error) {
-	decoder := json.NewDecoder(r)
-	var sum int64
-	for {
-		token, err := decoder.Token()
-		if err == io.EOF {
-			break
-		}
-		if v, ok := token.(float64); ok {
-			sum += int64(v)
-		}
-	}
-	return fmt.Sprint(sum), nil
+	return solve(r, 1)
 }
 
 func Part2(r io.Reader) (string, error) {
+	return solve(r, 2)
+}
+
+func solve(r io.Reader, part int) (string, error) {
 	var j interface{}
 	bytes, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -31,7 +24,7 @@ func Part2(r io.Reader) (string, error) {
 	if err := json.Unmarshal(bytes, &j); err != nil {
 		return "", fmt.Errorf("year 2015, day 12, part 2: %w", err)
 	}
-	return fmt.Sprint(sumJSON(j, 2)), nil
+	return fmt.Sprint(sumJSON(j, part)), nil
 }
 
 func sumJSON(j interface{}, part int) int {

--- a/go/internal/year2015/day12/day12_test.go
+++ b/go/internal/year2015/day12/day12_test.go
@@ -1,0 +1,29 @@
+package day12
+
+import (
+	"testing"
+
+	"github.com/Saser/adventofcode/internal/testcase"
+)
+
+const inputFile = "../testdata/12"
+
+func TestPart1(t *testing.T) {
+	for _, tc := range []testcase.TestCase{
+		testcase.FromString("example1_1", `[1,2,3]`, "6"),
+		testcase.FromString("example1_2", `{"a":2,"b":4}`, "6"),
+		testcase.FromString("example2_1", `[[[3]]]`, "3"),
+		testcase.FromString("example2_2", `{"a":{"b":4},"c":-1}`, "3"),
+		testcase.FromString("example3_1", `{"a":[-1,1]}`, "0"),
+		testcase.FromString("example3_2", `[-1,{"a":1}]`, "0"),
+		testcase.FromString("example4_1", `[]`, "0"),
+		testcase.FromString("example4_2", `{}`, "0"),
+	} {
+		testcase.Run(t, tc, Part1)
+	}
+}
+
+func BenchmarkPart1(b *testing.B) {
+	tc := testcase.FromFile(b, inputFile, "")
+	testcase.Bench(b, tc, Part1)
+}

--- a/go/internal/year2015/day12/day12_test.go
+++ b/go/internal/year2015/day12/day12_test.go
@@ -18,6 +18,7 @@ func TestPart1(t *testing.T) {
 		testcase.FromString("example3_2", `[-1,{"a":1}]`, "0"),
 		testcase.FromString("example4_1", `[]`, "0"),
 		testcase.FromString("example4_2", `{}`, "0"),
+		testcase.FromFile(t, inputFile, "111754"),
 	} {
 		testcase.Run(t, tc, Part1)
 	}

--- a/go/internal/year2015/day12/day12_test.go
+++ b/go/internal/year2015/day12/day12_test.go
@@ -28,3 +28,19 @@ func BenchmarkPart1(b *testing.B) {
 	tc := testcase.FromFile(b, inputFile, "")
 	testcase.Bench(b, tc, Part1)
 }
+
+func TestPart2(t *testing.T) {
+	for _, tc := range []testcase.TestCase{
+		testcase.FromString("example1", `[1,2,3]`, "6"),
+		testcase.FromString("example2", `[1,{"c":"red","b":2},3]`, "4"),
+		testcase.FromString("example3", `{"d":"red","e":[1,2,3,4],"f":5}`, "0"),
+		testcase.FromString("example4", `[1,"red",5]`, "6"),
+	} {
+		testcase.Run(t, tc, Part2)
+	}
+}
+
+func BenchmarkPart2(b *testing.B) {
+	tc := testcase.FromFile(b, inputFile, "")
+	testcase.Bench(b, tc, Part2)
+}

--- a/go/internal/year2015/day12/day12_test.go
+++ b/go/internal/year2015/day12/day12_test.go
@@ -35,6 +35,7 @@ func TestPart2(t *testing.T) {
 		testcase.FromString("example2", `[1,{"c":"red","b":2},3]`, "4"),
 		testcase.FromString("example3", `{"d":"red","e":[1,2,3,4],"f":5}`, "0"),
 		testcase.FromString("example4", `[1,"red",5]`, "6"),
+		testcase.FromFile(t, inputFile, "65402"),
 	} {
 		testcase.Run(t, tc, Part2)
 	}


### PR DESCRIPTION
My first solution was to walk over the token stream, which worked fine for part 1. However, that solution was difficult to adjust for part 2, since by then the tree structure of the JSON input was important. I resorted to simply using the built-in JSON decoding functionality, and simply walk that data structure.