### PR TITLE
cpp/2019: refactor `intcode` module to use member functions

### DIFF
--- a/cpp/year2019/day07/day07.cc
+++ b/cpp/year2019/day07/day07.cc
@@ -40,16 +40,17 @@ adventofcode::answer_t solve(std::istream& is, int part) {
     executions.clear();
     for (size_t i = 0; i < permutation.size(); i++) {
       auto e = intcode::execution {program};
-      intcode::write(e, permutation[i]);
+      e.write(permutation.at(i));
       executions.push_back(e);
     }
     auto signal = 0;
     auto current = 0;
-    while (executions[executions.size() - 1].state != intcode::execution_state::halted) {
-      auto &e = executions[current];
-      intcode::write(e, signal);
-      intcode::run(e);
-      signal = intcode::read(e);
+    auto& last = executions.at(executions.size() - 1);
+    while (last.state != intcode::execution_state::halted) {
+      auto &e = executions.at(current);
+      e.write(signal);
+      e.run();
+      signal = e.read();
       current = (current + 1) % executions.size();
     }
     max_signal = std::max(max_signal.value_or(signal), signal);

--- a/cpp/year2019/intcode/intcode.h
+++ b/cpp/year2019/intcode/intcode.h
@@ -52,34 +52,38 @@ namespace intcode {
     execution_state state = execution_state::initialized;
 
     execution(const memory& _m) : m(_m) {}
+
+    // Retrieves the value at `position` in memory, growing the memory if
+    // needed. If memory grows, all new elements are initialized to 0.
+    int64_t& at(size_t position);
+
+    // Return a copy of the current execution memory.
+    memory mem() const;
+
+    // Write an input value to the input of the execution.
+    void write(const int64_t& input);
+
+    // Write all provided input values to the input of the execution.
+    void write_all(const input& inputs);
+
+    // Read an output value produced by the execution. The value is consumed by
+    // reading it. Reading when no output is available is undefiend behavior.
+    int64_t read();
+
+    // Read all output produced by the execution. All output values are
+    // consumed.
+    output read_all();
+
+    // Runs the instruction at the current position in memory. Returns the next
+    // execution state. Running an instruction might cause the execution to
+    // enter the `halted` state, from which it will never transition to another
+    // state. If the current instruction is to read input, and no input is
+    // available, nothing happens, and the returned state will be `waiting`.
+    void run_instruction();
+
+    // Runs instructions until the execution halts or waits for input.
+    void run();
   };
-
-  // Return a copy of the current execution memory.
-  memory mem(const execution& e);
-
-  // Write an input value to the input of the execution.
-  void write(execution& e, const int64_t& i);
-
-  // Write all input values to the input of the execution.
-  void write_all(execution& e, const input& i);
-
-  // Read an output value produced by the execution. The value is consumed by
-  // reading it. Reading when no output is available is undefiend behavior.
-  int64_t read(execution& e);
-
-  // Read all output produced by the execution. All output values are
-  // consumed.
-  output read_all(execution& e);
-
-  // Runs the instruction at the current position in memory. Returns the next
-  // execution state. Running an instruction might cause the execution to
-  // enter the `halted` state, from which it will never transition to another
-  // state. If the current instruction is to read input, and no input is
-  // available, nothing happens, and the returned state will be `waiting`.
-  void run_instruction(execution& e);
-
-  // Runs instructions until the execution halts or waits for input.
-  void run(execution& e);
 
   // Determine the opcode for a given memory value.
   int opcode(int64_t instruction);

--- a/cpp/year2019/intcode/intcode.h
+++ b/cpp/year2019/intcode/intcode.h
@@ -20,7 +20,7 @@ namespace intcode {
     99, // halt
   };
 
-  enum parameter_mode {
+  enum class parameter_mode {
     position,
     immediate,
     relative,
@@ -35,7 +35,7 @@ namespace intcode {
   typedef std::deque<int64_t> input;
   typedef std::deque<int64_t> output;
 
-  enum execution_state {
+  enum class execution_state {
     initialized,
     running,
     waiting,


### PR DESCRIPTION
This also takes the opportunity to introduce bounds checking on all accesses to the execution's memory. Perhaps I should always use `.at()` instead of `[]` when accessing vectors, if nothing else then for the more verbose error messages (and not just segfaults).
