### PR TITLE
cpp/2019/12: optimize solution a bit

### DIFF
--- a/cpp/year2019/day12/day12.cc
+++ b/cpp/year2019/day12/day12.cc
@@ -103,15 +103,27 @@ void n_body_step(state& state) {
   apply_velocity(state);
 }
 
+bool states_equal(const state& s1, const state& s2) {
+  if (s1.size() != s2.size()) {
+    return false;
+  }
+  for (auto i = 0lu; i < s1.size(); i++) {
+    auto [p1, v1] = s1[i];
+    auto [p2, v2] = s2[i];
+    if (p1 != p2 || v1 != v2) {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::vector<state> find_cycle(const state& initial_state) {
-  std::set<state> states;
   std::vector<state> states_v;
   state state = initial_state;
-  while (states.find(state) == states.end()) {
-    states.insert(state);
+  do {
     states_v.push_back(state);
     n_body_step(state);
-  }
+  } while (!states_equal(state, initial_state));
   return states_v;
 }
 


### PR DESCRIPTION
We will always eventually reach the initial state, and therefore we do not need to keep track of all states we have visited. This is what I had in mind all the time (since that is why I do the modulo logic when finding the state after `n` steps), but for some reason overlooked it in this specific part of the program. This reduces the runtime by about 10x, from 650 ms to about 70 ms (both numbers are with compiler optimizations enabled).