### PR TITLE
cpp: rename stuff relating to Bazel repositories/dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,3 @@
-load("//cpp:repositories.bzl", "cpp_repositories")
+load("//cpp:deps.bzl", "cpp_dependencies")
 
-cpp_repositories()
+cpp_dependencies()

--- a/cpp/deps.bzl
+++ b/cpp/deps.bzl
@@ -1,13 +1,13 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-def cpp_repositories():
+def cpp_dependencies():
     git_repository(
         name = "googletest",
         remote = "https://github.com/google/googletest",
         # `commit` and `shallow_since` was given by first specifying:
         #     tag = "release-1.10.0"
         # and then following the debug messages given by Bazel.
-    commit = "703bd9caab50b139428cea1aaff9974ebee5742e",
+        commit = "703bd9caab50b139428cea1aaff9974ebee5742e",
         shallow_since = "1570114335 -0400",
     )
 


### PR DESCRIPTION
`repositories` is for the dependencies that are required for the BUILD files themselves; `dependencies` is for dependencies in the code to be built.