### PR TITLE
aocgen/templates/java: add IOException for part 2 actual input test

### DIFF
--- a/aocgen/templates/java/src/test/java/com/github/saser/adventofcode/yearYYYY/dayDD/DayDDTest.java
+++ b/aocgen/templates/java/src/test/java/com/github/saser/adventofcode/yearYYYY/dayDD/DayDDTest.java
@@ -37,7 +37,7 @@ public class Day{{.PaddedDay}}Test {
     // }
 
     // @Test
-    // public void part2Actual() {
+    // public void part2Actual() throws IOException {
     //     try (var input = new FileReader("inputs/{{.Year}}/{{.PaddedDay}}")) {
     //         var output = "";
     //         var result = Day{{.PaddedDay}}.part2(input);


### PR DESCRIPTION
Perhaps this is a lesson that I should not leave the tests commented in the template, so that issues like these are discovered sooner?