### PR TITLE
java: use milliseconds instead of nanoseconds as benchmark time unit

### DIFF
--- a/aocgen/templates/java/src/benchmark/java/com/github/saser/adventofcode/yearYYYY/dayDD/DayDDBenchmark.java
+++ b/aocgen/templates/java/src/benchmark/java/com/github/saser/adventofcode/yearYYYY/dayDD/DayDDBenchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
 @Measurement(iterations = 1, time = 1)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 public class Day{{.PaddedDay}}Benchmark {

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day01/Day01Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day01/Day01Benchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
 @Measurement(iterations = 1, time = 1)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 public class Day01Benchmark {

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day02/Day02Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day02/Day02Benchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
 @Measurement(iterations = 1, time = 1)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 public class Day02Benchmark {

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day03/Day03Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day03/Day03Benchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
 @Measurement(iterations = 1, time = 1)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 public class Day03Benchmark {


### PR DESCRIPTION
This also updates the templates correspondingly.

I am usually not interested in nanosecond precision: most of my solutions have a benchmarked time ranging from 10 microseconds to several seconds, with most of them being less than one second. As such, milliseconds is the most interesting time unit.