### PR TITLE
Add .bazelignore for `aocgen`, `go`, and `rust`

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+aocgen
+go
+rust


### PR DESCRIPTION
These are not yet built using Bazel, so they should probably be ignored. More specifically, `aocgen` contains templates for BUILD files, but they should not be considered actual packages. `go` and `rust` are ignored so that Bazel does not happen to pick up anything
there (though I eventually intend to build these directories using Bazel as well).