### PR TITLE
java: add solution for year 2016, day 25

### DIFF
--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -1,0 +1,19 @@
+java_library(
+    name = "benchmark_library",
+    srcs = glob(["*.java"]),
+    deps = [
+        "@maven//:org_openjdk_jmh_jmh_core",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day25:day25",
+    ],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    data = ["//inputs:2016/25"],
+)
+
+java_binary(
+    name = "benchmark",
+    main_class = "org.openjdk.jmh.Main",
+    runtime_deps = [
+        "@maven//:org_openjdk_jmh_jmh_core",
+        ":benchmark_library",
+    ],
+)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/Day25Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/Day25Benchmark.java
@@ -1,0 +1,49 @@
+package com.github.saser.adventofcode.year2016.day25;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Measurement(iterations = 1, time = 1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+public class Day25Benchmark {
+    private Reader input;
+
+    @Setup
+    public void setup() throws IOException {
+        var path = FileSystems.getDefault().getPath("inputs", "2016", "25");
+        var contents = Files.readString(path);
+        this.input = new StringReader(contents);
+    }
+        
+    @Benchmark
+    public void part1() throws IOException {
+        Day25.part1(this.input);
+        this.input.reset();
+    }
+        
+    @Benchmark
+    public void part2() throws IOException {
+        Day25.part2(this.input);
+        this.input.reset();
+    }
+}

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/Day25Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/Day25Benchmark.java
@@ -40,10 +40,4 @@ public class Day25Benchmark {
         Day25.part1(this.input);
         this.input.reset();
     }
-        
-    @Benchmark
-    public void part2() throws IOException {
-        Day25.part2(this.input);
-        this.input.reset();
-    }
 }

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
@@ -97,6 +97,14 @@ public class VM {
         this.register("d", i);
     }
 
+    public void reset() {
+        this.pc = 0;
+        this.a(0);
+        this.b(0);
+        this.c(0);
+        this.d(0);
+    }
+
     public List<Integer> runAll() {
         var output = new ArrayList<Integer>();
         while (this.pc < this.program.length) {

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 public class VM {
@@ -11,14 +12,14 @@ public class VM {
     public int pc;
     public int[] registers;
 
-    public VM(String[] program, int pc, int a, int b, int c, int d) {
-        this.program = splitProgram(program);
+    public VM(String[][] program, int pc, int a, int b, int c, int d) {
+        this.program = program;
         this.pc = pc;
         this.registers = new int[] {a, b, c, d};
     }
 
     public VM(String[] program) {
-        this(program, 0, 0, 0, 0, 0);
+        this(splitProgram(program), 0, 0, 0, 0, 0);
     }
 
     public static VM from(Reader r) {
@@ -33,6 +34,33 @@ public class VM {
         return Arrays.stream(program)
                 .map(instruction -> instruction.split(" "))
                 .toArray(String[][]::new);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VM vm = (VM) o;
+        return pc == vm.pc &&
+                Arrays.equals(program, vm.program) &&
+                Arrays.equals(registers, vm.registers);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(pc);
+        result = 31 * result + Arrays.hashCode(program);
+        result = 31 * result + Arrays.hashCode(registers);
+        return result;
+    }
+
+    @Override
+    public VM clone() {
+        var program = new String[this.program.length][];
+        for (var i = 0; i < program.length; i++) {
+            program[i] = this.program[i].clone();
+        }
+        return new VM(program, this.pc, this.a(), this.b(), this.c(), this.d());
     }
 
     public int a() {

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
@@ -3,7 +3,9 @@ package com.github.saser.adventofcode.year2016.assembunny;
 import java.io.BufferedReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -95,13 +97,15 @@ public class VM {
         this.register("d", i);
     }
 
-    public void runAll() {
+    public List<Integer> runAll() {
+        var output = new ArrayList<Integer>();
         while (this.pc < this.program.length) {
-            this.run();
+            this.run().ifPresent(output::add);
         }
+        return output;
     }
 
-    public void run() {
+    public Optional<Integer> run() {
         var instruction = this.program[this.pc];
         var op = instruction[0];
         var param1 = instruction[1];
@@ -113,6 +117,7 @@ public class VM {
             value2 = Optional.of(this.valueOf(param2.get()));
         }
         var delta = 1;
+        var out = Optional.<Integer>empty();
         switch (op) {
             case "cpy":
                 try {
@@ -152,10 +157,14 @@ public class VM {
                 }
                 break;
             }
+            case "out":
+                out = Optional.of(value1);
+                break;
             default:
                 throw new IllegalArgumentException(String.format("invalid op: %s", op));
         }
         this.pc += delta;
+        return out;
     }
 
     private int registerOffset(String x) {

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/VM.java
@@ -21,10 +21,6 @@ public class VM {
         this(program, 0, 0, 0, 0, 0);
     }
 
-    public VM() {
-        this(new String[0]);
-    }
-
     public static VM from(Reader r) {
         return new VM(new BufferedReader(r).lines().toArray(String[]::new));
     }

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "day25",
+    srcs = glob(["*.java"]),
+    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+)

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -3,5 +3,8 @@ package(default_visibility = ["//visibility:public"])
 java_library(
     name = "day25",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/assembunny:assembunny",
+        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+    ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day25/Day25.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day25/Day25.java
@@ -1,0 +1,19 @@
+package com.github.saser.adventofcode.year2016.day25;
+
+import java.io.Reader;
+
+import com.github.saser.adventofcode.Result;
+
+public final class Day25 {
+    public static Result part1(Reader r) {
+        return solve(r, 1);
+    }
+
+    public static Result part2(Reader r) {
+        return solve(r, 2);
+    }
+
+    private static Result solve(Reader r, int part) {
+        return Result.err("not implemented yet");
+    }
+}

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day25/Day25.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day25/Day25.java
@@ -6,14 +6,6 @@ import com.github.saser.adventofcode.Result;
 import com.github.saser.adventofcode.year2016.assembunny.VM;
 
 public final class Day25 {
-    public static Result part1(Reader r) {
-        return solve(r, 1);
-    }
-
-    public static Result part2(Reader r) {
-        return solve(r, 2);
-    }
-
     // My initial attempt consisted of trying to find a loop in the states of
     // the VM, based on the pattern `{0, 1}`. However, I expected the loop to be
     // exactly as long as the pattern, i.e., 2 states.
@@ -35,7 +27,7 @@ public final class Day25 {
     // simply start by setting `a` to zero, and as long as a is less than
     // `bound`, we shift `a` left two times, and add `10` as the new least
     // significant bits. When we have found `a`, the answer is `a - bound`.
-    private static Result solve(Reader r, int part) {
+    public static Result part1(Reader r) {
         var vm = VM.from(r);
         for (var i = 0; i < 3; i++) {
             vm.run();

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day25/Day25.java
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day25/Day25.java
@@ -3,6 +3,7 @@ package com.github.saser.adventofcode.year2016.day25;
 import java.io.Reader;
 
 import com.github.saser.adventofcode.Result;
+import com.github.saser.adventofcode.year2016.assembunny.VM;
 
 public final class Day25 {
     public static Result part1(Reader r) {
@@ -13,7 +14,38 @@ public final class Day25 {
         return solve(r, 2);
     }
 
+    // My initial attempt consisted of trying to find a loop in the states of
+    // the VM, based on the pattern `{0, 1}`. However, I expected the loop to be
+    // exactly as long as the pattern, i.e., 2 states.
+    //
+    // After some initial failures, I just ran the program for a couple of
+    // inputs and noted the values of the registers at different times, as well
+    // as what was output. Turns out that the output is the binary
+    // representation of a number, in reverse order, not limited to a certain
+    // number of bits. In other words, we do not care about leading zeroes.
+    //
+    // The number, which I decided to call `bound`, is equal to what we choose
+    // as `a`, plus a product of the values of `b` and `c` after an initial
+    // setup. This setup consists of 3 instructions, which is why the first
+    // three instructions are executed below.
+    //
+    // After we have found the bound, then we simply have to find the lowest
+    // integer that is at least as large as bound, and whose binary
+    // representation (without leading zeroes) is `10` repeating. To do that, we
+    // simply start by setting `a` to zero, and as long as a is less than
+    // `bound`, we shift `a` left two times, and add `10` as the new least
+    // significant bits. When we have found `a`, the answer is `a - bound`.
     private static Result solve(Reader r, int part) {
-        return Result.err("not implemented yet");
+        var vm = VM.from(r);
+        for (var i = 0; i < 3; i++) {
+            vm.run();
+        }
+        var bound = vm.b() * vm.c();
+        var a = 0;
+        while (a < bound) {
+            a <<= 2;
+            a |= 0b10;
+        }
+        return Result.ok(Integer.toString(a - bound));
     }
 }

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
@@ -195,6 +195,29 @@ public class VMTest {
     }
 
     @Test
+    public void testReset() {
+        var program = new String[] {
+                "cpy 1 a",
+                "cpy 2 b",
+                "cpy 3 c",
+                "cpy 4 d",
+        };
+        var vm = new VM(program);
+        vm.runAll();
+        Assert.assertEquals(1, vm.a());
+        Assert.assertEquals(2, vm.b());
+        Assert.assertEquals(3, vm.c());
+        Assert.assertEquals(4, vm.d());
+        Assert.assertEquals(4, vm.pc);
+        vm.reset();
+        Assert.assertEquals(0, vm.a());
+        Assert.assertEquals(0, vm.b());
+        Assert.assertEquals(0, vm.c());
+        Assert.assertEquals(0, vm.d());
+        Assert.assertEquals(0, vm.pc);
+    }
+
+    @Test
     public void testDay12Example() {
         var r = new InputStreamReader(this.getClass().getResourceAsStream("day12example"));
         var vm = VM.from(r);

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
@@ -93,7 +93,7 @@ public class VMTest {
 
     @Test
     public void testSetRegisters() {
-        var vm = new VM(new String[0], 0, 0, 0, 0, 0);
+        var vm = new VM(new String[0][0], 0, 0, 0, 0, 0);
         vm.a(1);
         Assert.assertEquals(1, vm.a());
         vm.b(2);

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
@@ -93,6 +93,65 @@ public class VMTest {
     }
 
     @Test
+    public void testTglOneArgument() {
+        var program = new String[] {
+                "tgl 1",
+                "inc a", // will become `dec a`, producing a = -1
+                "tgl 1",
+                "dec b", // will become `inc b`, producing b = 1
+                "tgl 1",
+                "tgl c", // will become `inc c`, producing c = 1
+                "tgl 1",
+                "out d", // will become `inc d`, producing d = 1
+        };
+        var vm = new VM(program);
+        vm.runAll();
+        Assert.assertEquals(-1, vm.a());
+        Assert.assertEquals(1, vm.b());
+        Assert.assertEquals(1, vm.c());
+        Assert.assertEquals(1, vm.d());
+    }
+
+    @Test
+    public void testTglTwoArguments() {
+        var program = new String[] {
+                "tgl 1",
+                "jnz 1 a", // will become `cpy 1 a`, producing a = 1
+                "tgl 1",
+                "cpy 1 2", // will become `jnz 1 2`...
+                "cpy 1 b", // which will skip this instruction...
+                "cpy 2 b", // producing b = 2
+        };
+        var vm = new VM(program);
+        vm.runAll();
+        Assert.assertEquals(1, vm.a());
+        Assert.assertEquals(2, vm.b());
+    }
+
+    @Test
+    public void testTglSelf() {
+        var program = new String[] {
+                "tgl a", // a == 0, so this will become `inc a`
+                "dec a", // the previous instruction should be skipped, producing a = -1
+        };
+        var vm = new VM(program);
+        vm.runAll();
+        Assert.assertEquals(-1, vm.a());
+    }
+
+    @Test
+    public void testTglIllegal() {
+        var program = new String[] {
+                "tgl 1",
+                "jnz 1 2", // will become `cpy 1 2`, which is illegal and should be skipped...
+                "cpy 1 a", // producing a = 1
+        };
+        var vm = new VM(program);
+        vm.runAll();
+        Assert.assertEquals(1, vm.a());
+    }
+
+    @Test
     public void testOutImmediate() {
         var vm = VM.from("out 1");
         var outputs = vm.runAll();

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/VMTest.java
@@ -1,6 +1,7 @@
 package com.github.saser.adventofcode.year2016.assembunny;
 
 import java.io.InputStreamReader;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -89,6 +90,36 @@ public class VMTest {
         var vm = new VM(program);
         vm.runAll();
         Assert.assertEquals(2, vm.a());
+    }
+
+    @Test
+    public void testOutImmediate() {
+        var vm = VM.from("out 1");
+        var outputs = vm.runAll();
+        Assert.assertEquals(List.of(1), outputs);
+    }
+
+    @Test
+    public void testOutRegister() {
+        var program = new String[] {
+                "cpy 1 a",
+                "out a",
+        };
+        var vm = new VM(program);
+        var outputs = vm.runAll();
+        Assert.assertEquals(List.of(1), outputs);
+    }
+
+    @Test
+    public void testOutMultiple() {
+        var program = new String[] {
+                "out 1",
+                "out 2",
+                "out 3",
+        };
+        var vm = new VM(program);
+        var outputs = vm.runAll();
+        Assert.assertEquals(List.of(1, 2, 3), outputs);
     }
 
     @Test

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -1,0 +1,11 @@
+java_test(
+    name = "test",
+    srcs = glob(["*.java"]),
+    test_class = "com.github.saser.adventofcode.year2016.day25.Day25Test",
+    deps = [
+        "@maven//:junit_junit",
+        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day25:day25",
+    ],
+    data = ["//inputs:2016/25"],
+)

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day25/Day25Test.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day25/Day25Test.java
@@ -1,0 +1,38 @@
+package com.github.saser.adventofcode.year2016.day25;
+
+import java.io.FileReader;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+public class Day25Test {
+    @Test
+    public void part1Actual() throws IOException {
+        try (var input = new FileReader("inputs/2016/25")) {
+            var output = "";
+            var result = Day25.part1(input);
+            Assert.assertEquals("no error", "", result.error);
+            Assert.assertEquals("correct output", output, result.answer);
+        }
+    }
+
+    // @Test
+    // public void part2Example() {
+    //     var input = new StringReader("");
+    //     var output = "";
+    //     var result = Day25.part2(input);
+    //     Assert.assertEquals("no error", "", result.error);
+    //     Assert.assertEquals("correct output", output, result.answer);
+    // }
+
+    // @Test
+    // public void part2Actual() throws IOException {
+    //     try (var input = new FileReader("inputs/2016/25")) {
+    //         var output = "";
+    //         var result = Day25.part2(input);
+    //         Assert.assertEquals("no error", "", result.error);
+    //         Assert.assertEquals("correct output", output, result.answer);
+    //     }
+    // }
+}

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day25/Day25Test.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day25/Day25Test.java
@@ -16,23 +16,4 @@ public class Day25Test {
             Assert.assertEquals("correct output", output, result.answer);
         }
     }
-
-    // @Test
-    // public void part2Example() {
-    //     var input = new StringReader("");
-    //     var output = "";
-    //     var result = Day25.part2(input);
-    //     Assert.assertEquals("no error", "", result.error);
-    //     Assert.assertEquals("correct output", output, result.answer);
-    // }
-
-    // @Test
-    // public void part2Actual() throws IOException {
-    //     try (var input = new FileReader("inputs/2016/25")) {
-    //         var output = "";
-    //         var result = Day25.part2(input);
-    //         Assert.assertEquals("no error", "", result.error);
-    //         Assert.assertEquals("correct output", output, result.answer);
-    //     }
-    // }
 }

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day25/Day25Test.java
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day25/Day25Test.java
@@ -10,7 +10,7 @@ public class Day25Test {
     @Test
     public void part1Actual() throws IOException {
         try (var input = new FileReader("inputs/2016/25")) {
-            var output = "";
+            var output = "192";
             var result = Day25.part1(input);
             Assert.assertEquals("no error", "", result.error);
             Assert.assertEquals("correct output", output, result.answer);


### PR DESCRIPTION
That concludes year 2016!

This final assembunny problem could of course be solved by reverse engineering, but I did a more "soft reverse engineering" this time. Instead of trying to study the code in detail, I just ran the program for a couple of inputs (i.e. values of `a`), and noted the values of the registers as well as what was output. From there I solved the problem -- read more in the comments of the `part1` function.

I think it is a little bit sad that all of these assembunny problems did not really require you to implement and use your VM -- you could just reverse engineer everything instead. I liked year 2019 better that way: you really had to implement the intcode VM there, since several of the problems more heavily relied on actually running intcode programs, not simply reverse engineer them.

Anyway, rant over. I am happy that I am done with year 2016 now! Now there is only a few days each left in years 2017 and 2018 before I have completed all of the puzzles.