### PR TITLE
Run `buildifier -lint=fix -warnings=all -r .`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,11 @@
 load("//cpp:deps.bzl", "cpp_dependencies")
+
 cpp_dependencies()
 
 load("//java:repos.bzl", "java_repositories")
+
 java_repositories()
+
 load("//java:deps.bzl", "java_dependencies")
+
 java_dependencies()

--- a/aocgen/templates/cpp/yearYYYY/dayDD/BUILD.bazel
+++ b/aocgen/templates/cpp/yearYYYY/dayDD/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "{{.FullDay}}",
-    hdrs = ["{{.FullDay}}.h"],
     srcs = ["{{.FullDay}}.cc"],
+    hdrs = ["{{.FullDay}}.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
     deps = [
         ":{{.FullDay}}",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
     deps = [
         ":{{.FullDay}}",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
 )

--- a/aocgen/templates/java/src/benchmark/java/com/github/saser/adventofcode/yearYYYY/dayDD/BUILD.bazel
+++ b/aocgen/templates/java/src/benchmark/java/com/github/saser/adventofcode/yearYYYY/dayDD/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/{{.FullYear}}/{{.FullDay}}:{{.FullDay}}",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/{{.FullYear}}/{{.FullDay}}",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/aocgen/templates/java/src/main/java/com/github/saser/adventofcode/yearYYYY/dayDD/BUILD.bazel
+++ b/aocgen/templates/java/src/main/java/com/github/saser/adventofcode/yearYYYY/dayDD/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "{{.FullDay}}",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/aocgen/templates/java/src/test/java/com/github/saser/adventofcode/yearYYYY/dayDD/BUILD.bazel
+++ b/aocgen/templates/java/src/test/java/com/github/saser/adventofcode/yearYYYY/dayDD/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
     test_class = "com.github.saser.adventofcode.{{.FullYear}}.{{.FullDay}}.Day{{.PaddedDay}}Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/{{.FullYear}}/{{.FullDay}}",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/{{.FullYear}}/{{.FullDay}}:{{.FullDay}}",
     ],
-    data = ["//inputs:{{.Year}}/{{.PaddedDay}}"],
 )

--- a/cpp/BUILD.bazel
+++ b/cpp/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "adventofcode",
-    hdrs = ["adventofcode.h"],
     srcs = ["adventofcode.cc"],
+    hdrs = ["adventofcode.h"],
 )

--- a/cpp/year2019/day01/BUILD.bazel
+++ b/cpp/year2019/day01/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day01",
-    hdrs = ["day01.h"],
     srcs = ["day01.cc"],
+    hdrs = ["day01.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/01"],
     deps = [
         ":day01",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/01"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/01"],
     deps = [
         ":day01",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/01"],
 )

--- a/cpp/year2019/day02/BUILD.bazel
+++ b/cpp/year2019/day02/BUILD.bazel
@@ -1,30 +1,32 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day02",
-    hdrs = ["day02.h"],
     srcs = ["day02.cc"],
+    hdrs = ["day02.h"],
     deps = [
-        "@abseil//absl/strings:strings",
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
+        "@abseil//absl/strings",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/02"],
     deps = [
         ":day02",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/02"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/02"],
     deps = [
         ":day02",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/02"],
 )

--- a/cpp/year2019/day03/BUILD.bazel
+++ b/cpp/year2019/day03/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day03",
-    hdrs = ["day03.h"],
     srcs = ["day03.cc"],
+    hdrs = ["day03.h"],
     deps = [
-        "@abseil//absl/strings:strings",
         "//cpp:adventofcode",
+        "@abseil//absl/strings",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/03"],
     deps = [
         ":day03",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/03"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/03"],
     deps = [
         ":day03",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/03"],
 )

--- a/cpp/year2019/day04/BUILD.bazel
+++ b/cpp/year2019/day04/BUILD.bazel
@@ -1,28 +1,30 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day04",
-    hdrs = ["day04.h"],
     srcs = ["day04.cc"],
+    hdrs = ["day04.h"],
     deps = [
-        "@abseil//absl/strings:strings",
-        "//cpp:adventofcode",
         ":internal",
+        "//cpp:adventofcode",
+        "@abseil//absl/strings",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/04"],
     deps = [
         ":day04",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/04"],
 )
 
 cc_library(
     name = "internal",
-    hdrs = ["internal.h"],
     srcs = ["internal.cc"],
+    hdrs = ["internal.h"],
 )
 
 cc_test(
@@ -37,9 +39,9 @@ cc_test(
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/04"],
     deps = [
         ":day04",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/04"],
 )

--- a/cpp/year2019/day05/BUILD.bazel
+++ b/cpp/year2019/day05/BUILD.bazel
@@ -1,30 +1,32 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day05",
-    hdrs = ["day05.h"],
     srcs = ["day05.cc"],
+    hdrs = ["day05.h"],
     deps = [
-        "@abseil//absl/strings:str_format",
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
+        "@abseil//absl/strings:str_format",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/05"],
     deps = [
         ":day05",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/05"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/05"],
     deps = [
         ":day05",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/05"],
 )

--- a/cpp/year2019/day06/BUILD.bazel
+++ b/cpp/year2019/day06/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day06",
-    hdrs = ["day06.h"],
     srcs = ["day06.cc"],
+    hdrs = ["day06.h"],
     deps = [
-        "@abseil//absl/strings:strings",
         "//cpp:adventofcode",
+        "@abseil//absl/strings",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/06"],
     deps = [
         ":day06",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/06"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/06"],
     deps = [
         ":day06",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/06"],
 )

--- a/cpp/year2019/day07/BUILD.bazel
+++ b/cpp/year2019/day07/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day07",
-    hdrs = ["day07.h"],
     srcs = ["day07.cc"],
+    hdrs = ["day07.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/07"],
     deps = [
         ":day07",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/07"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/07"],
     deps = [
         ":day07",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/07"],
 )

--- a/cpp/year2019/day08/BUILD.bazel
+++ b/cpp/year2019/day08/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day08",
-    hdrs = ["day08.h"],
     srcs = ["day08.cc"],
+    hdrs = ["day08.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/08"],
     deps = [
         ":day08",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/08"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/08"],
     deps = [
         ":day08",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/08"],
 )

--- a/cpp/year2019/day09/BUILD.bazel
+++ b/cpp/year2019/day09/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day09",
-    hdrs = ["day09.h"],
     srcs = ["day09.cc"],
+    hdrs = ["day09.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/09"],
     deps = [
         ":day09",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/09"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/09"],
     deps = [
         ":day09",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/09"],
 )

--- a/cpp/year2019/day10/BUILD.bazel
+++ b/cpp/year2019/day10/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day10",
-    hdrs = ["day10.h"],
     srcs = ["day10.cc"],
+    hdrs = ["day10.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/10"],
     deps = [
         ":day10",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/10"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/10"],
     deps = [
         ":day10",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/10"],
 )

--- a/cpp/year2019/day11/BUILD.bazel
+++ b/cpp/year2019/day11/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day11",
-    hdrs = ["day11.h"],
     srcs = ["day11.cc"],
+    hdrs = ["day11.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/11"],
     deps = [
         ":day11",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/11"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/11"],
     deps = [
         ":day11",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/11"],
 )

--- a/cpp/year2019/day12/BUILD.bazel
+++ b/cpp/year2019/day12/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day12",
-    hdrs = ["day12.h"],
     srcs = ["day12.cc"],
+    hdrs = ["day12.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/12"],
     deps = [
         ":day12",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/12"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/12"],
     deps = [
         ":day12",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/12"],
 )

--- a/cpp/year2019/day13/BUILD.bazel
+++ b/cpp/year2019/day13/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day13",
-    hdrs = ["day13.h"],
     srcs = ["day13.cc"],
+    hdrs = ["day13.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/13"],
     deps = [
         ":day13",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/13"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/13"],
     deps = [
         ":day13",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/13"],
 )

--- a/cpp/year2019/day14/BUILD.bazel
+++ b/cpp/year2019/day14/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day14",
-    hdrs = ["day14.h"],
     srcs = ["day14.cc"],
+    hdrs = ["day14.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/14"],
     deps = [
         ":day14",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/14"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/14"],
     deps = [
         ":day14",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/14"],
 )

--- a/cpp/year2019/day15/BUILD.bazel
+++ b/cpp/year2019/day15/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day15",
-    hdrs = ["day15.h"],
     srcs = ["day15.cc"],
+    hdrs = ["day15.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/15"],
     deps = [
         ":day15",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/15"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/15"],
     deps = [
         ":day15",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/15"],
 )

--- a/cpp/year2019/day16/BUILD.bazel
+++ b/cpp/year2019/day16/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day16",
-    hdrs = ["day16.h"],
     srcs = ["day16.cc"],
+    hdrs = ["day16.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/16"],
     deps = [
         ":day16",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/16"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/16"],
     deps = [
         ":day16",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/16"],
 )

--- a/cpp/year2019/day17/BUILD.bazel
+++ b/cpp/year2019/day17/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day17",
-    hdrs = ["day17.h"],
     srcs = ["day17.cc"],
+    hdrs = ["day17.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/17"],
     deps = [
         ":day17",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/17"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/17"],
     deps = [
         ":day17",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/17"],
 )

--- a/cpp/year2019/day18/BUILD.bazel
+++ b/cpp/year2019/day18/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day18",
-    hdrs = ["day18.h"],
     srcs = ["day18.cc"],
+    hdrs = ["day18.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/18"],
     deps = [
         ":day18",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/18"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/18"],
     deps = [
         ":day18",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/18"],
 )

--- a/cpp/year2019/day19/BUILD.bazel
+++ b/cpp/year2019/day19/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day19",
-    hdrs = ["day19.h"],
     srcs = ["day19.cc"],
+    hdrs = ["day19.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/19"],
     deps = [
         ":day19",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/19"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/19"],
     deps = [
         ":day19",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/19"],
 )

--- a/cpp/year2019/day20/BUILD.bazel
+++ b/cpp/year2019/day20/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day20",
-    hdrs = ["day20.h"],
     srcs = ["day20.cc"],
+    hdrs = ["day20.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/20"],
     deps = [
         ":day20",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/20"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/20"],
     deps = [
         ":day20",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/20"],
 )

--- a/cpp/year2019/day21/BUILD.bazel
+++ b/cpp/year2019/day21/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day21",
-    hdrs = ["day21.h"],
     srcs = ["day21.cc"],
+    hdrs = ["day21.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/21"],
     deps = [
         ":day21",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/21"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/21"],
     deps = [
         ":day21",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/21"],
 )

--- a/cpp/year2019/day22/BUILD.bazel
+++ b/cpp/year2019/day22/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day22",
-    hdrs = ["day22.h"],
     srcs = ["day22.cc"],
+    hdrs = ["day22.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/22"],
     deps = [
         ":day22",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/22"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/22"],
     deps = [
         ":day22",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/22"],
 )

--- a/cpp/year2019/day23/BUILD.bazel
+++ b/cpp/year2019/day23/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day23",
-    hdrs = ["day23.h"],
     srcs = ["day23.cc"],
+    hdrs = ["day23.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/23"],
     deps = [
         ":day23",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/23"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/23"],
     deps = [
         ":day23",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/23"],
 )

--- a/cpp/year2019/day24/BUILD.bazel
+++ b/cpp/year2019/day24/BUILD.bazel
@@ -1,26 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day24",
-    hdrs = ["day24.h"],
     srcs = ["day24.cc"],
+    hdrs = ["day24.h"],
     deps = ["//cpp:adventofcode"],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = glob(["testdata/*"]) + ["//inputs:2019/24"],
     deps = [
         ":day24",
         "@googletest//:gtest_main",
     ],
-    data = glob(["testdata/*"]) + ["//inputs:2019/24"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/24"],
     deps = [
         ":day24",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/24"],
 )

--- a/cpp/year2019/day25/BUILD.bazel
+++ b/cpp/year2019/day25/BUILD.bazel
@@ -1,29 +1,31 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+
 cc_library(
     name = "day25",
-    hdrs = ["day25.h"],
     srcs = ["day25.cc"],
+    hdrs = ["day25.h"],
     deps = [
         "//cpp:adventofcode",
-        "//cpp/year2019/intcode:intcode",
+        "//cpp/year2019/intcode",
     ],
 )
 
 cc_test(
     name = "test",
     srcs = ["test.cc"],
+    data = ["//inputs:2019/25"],
     deps = [
         ":day25",
         "@googletest//:gtest_main",
     ],
-    data = ["//inputs:2019/25"],
 )
 
 cc_binary(
     name = "benchmark",
     srcs = ["benchmark.cc"],
+    data = ["//inputs:2019/25"],
     deps = [
         ":day25",
         "@googlebenchmark//:benchmark_main",
     ],
-    data = ["//inputs:2019/25"],
 )

--- a/cpp/year2019/intcode/BUILD.bazel
+++ b/cpp/year2019/intcode/BUILD.bazel
@@ -1,9 +1,11 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 cc_library(
     name = "intcode",
-    hdrs = ["intcode.h"],
     srcs = ["intcode.cc"],
-    deps = ["@abseil//absl/strings:strings"],
-    visibility = ["//visibility:public"]
+    hdrs = ["intcode.h"],
+    visibility = ["//visibility:public"],
+    deps = ["@abseil//absl/strings"],
 )
 
 cc_test(

--- a/java/deps.bzl
+++ b/java/deps.bzl
@@ -8,6 +8,6 @@ def java_dependencies():
             "org.openjdk.jmh:jmh-generator-annprocess:1.22",
         ],
         repositories = [
-            "https://repo1.maven.org/maven2"
+            "https://repo1.maven.org/maven2",
         ],
     )

--- a/java/src/benchmark/BUILD.bazel
+++ b/java/src/benchmark/BUILD.bazel
@@ -1,6 +1,8 @@
+load("@rules_java//java:defs.bzl", "java_plugin")
+
 java_plugin(
     name = "annotation_processor",
-    deps = ["@maven//:org_openjdk_jmh_jmh_generator_annprocess"],
     processor_class = "org.openjdk.jmh.generators.BenchmarkProcessor",
     visibility = ["//java/src/benchmark:__subpackages__"],
+    deps = ["@maven//:org_openjdk_jmh_jmh_generator_annprocess"],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day01/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day01/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day01:day01",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/01"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day01",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day02/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day02/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day02:day02",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/02"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day02",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day03/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day03/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day03:day03",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/03"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day03",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day04/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day04/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day04:day04",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/04"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day04",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day05/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day05/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day05:day05",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/05"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day05",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day06/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day06/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day06:day06",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/06"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day06",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day07/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day07/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day07:day07",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/07"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day07",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day08/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day08/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day08:day08",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/08"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day08",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day09/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day09/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day09:day09",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/09"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day09",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day10/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day10/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day10:day10",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/10"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day10",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day11/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day11/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day11:day11",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/11"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day11",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day12/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day12/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day12:day12",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/12"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day12",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day13/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day13/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day13:day13",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/13"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day13",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day14/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day14/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day14:day14",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/14"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day14",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day15/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day15/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day15:day15",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/15"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day15",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day16/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day16/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day16:day16",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/16"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day16",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day17/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day17/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day17:day17",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/17"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day17",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day18/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day18/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day18:day18",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/18"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day18",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day19/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day19/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day19:day19",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/19"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day19",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day20/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day20/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day20:day20",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/20"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day20",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day21/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day21/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day21:day21",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/21"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day21",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day22/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day22/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day22:day22",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/22"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day22",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day23/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day23/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day23:day23",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/23"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day23",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day24/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day24/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day24:day24",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/24"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day24",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -1,19 +1,21 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "benchmark_library",
     srcs = glob(["*.java"]),
-    deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day25:day25",
-    ],
-    plugins = ["//java/src/benchmark:annotation_processor"],
     data = ["//inputs:2016/25"],
+    plugins = ["//java/src/benchmark:annotation_processor"],
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day25",
+        "@maven//:org_openjdk_jmh_jmh_core",
+    ],
 )
 
 java_binary(
     name = "benchmark",
     main_class = "org.openjdk.jmh.Main",
     runtime_deps = [
-        "@maven//:org_openjdk_jmh_jmh_core",
         ":benchmark_library",
+        "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/java/src/main/java/com/github/saser/adventofcode/geo/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/geo/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/java/src/main/java/com/github/saser/adventofcode/tuple/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/tuple/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/assembunny/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day01/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day01/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day01",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/geo:geo",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/geo",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day02/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day02/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day02",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/geo:geo",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/geo",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day03/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day03/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day03",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day04/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day04/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day04",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day05/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day05/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day05",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day06/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day06/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day06",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day07/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day07/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day07",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day08/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day08/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day08",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day09/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day09/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day09",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day10/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day10/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day10",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day11/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day11/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day11",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day12/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day12/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day12",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/assembunny:assembunny",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/assembunny",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day13/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day13/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day13",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/geo:geo",
-        "//java/src/main/java/com/github/saser/adventofcode/tuple:tuple",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/geo",
+        "//java/src/main/java/com/github/saser/adventofcode/tuple",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day14/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day14/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day14",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day15/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day15/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day15",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/tuple:tuple",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/tuple",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day16/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day16/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day16",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day17/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day17/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day17",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/geo:geo",
-        "//java/src/main/java/com/github/saser/adventofcode/tuple:tuple",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/geo",
+        "//java/src/main/java/com/github/saser/adventofcode/tuple",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day18/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day18/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day18",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day19/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day19/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day19",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day20/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day20/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day20",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/tuple:tuple",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/tuple",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day21/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day21/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day21",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day22/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day22/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day22",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/geo:geo",
-        "//java/src/main/java/com/github/saser/adventofcode/tuple:tuple",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/geo",
+        "//java/src/main/java/com/github/saser/adventofcode/tuple",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day23/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day23/BUILD.bazel
@@ -1,7 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day23",
     srcs = glob(["*.java"]),
-    deps = ["//java/src/main/java/com/github/saser/adventofcode:adventofcode"],
+    deps = ["//java/src/main/java/com/github/saser/adventofcode"],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day24/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day24/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day24",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/geo:geo",
-        "//java/src/main/java/com/github/saser/adventofcode/tuple:tuple",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/geo",
+        "//java/src/main/java/com/github/saser/adventofcode/tuple",
     ],
 )

--- a/java/src/main/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/main/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "day25",
     srcs = glob(["*.java"]),
     deps = [
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/assembunny:assembunny",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/assembunny",
     ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/assembunny/BUILD.bazel
@@ -1,10 +1,12 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.assembunny.VMTest",
     resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/assembunny:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.assembunny.VMTest",
     deps = [
-        "@maven//:junit_junit",
         "//java/src/main/java/com/github/saser/adventofcode/year2016/assembunny",
+        "@maven//:junit_junit",
     ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day01/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day01/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/01"],
     test_class = "com.github.saser.adventofcode.year2016.day01.Day01Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day01",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day01:day01",
     ],
-    data = ["//inputs:2016/01"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day02/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day02/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day02.Day02Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day02:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day02:day02",
-    ],
     data = ["//inputs:2016/02"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day02:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day02.Day02Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day02",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day03/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day03/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/03"],
     test_class = "com.github.saser.adventofcode.year2016.day03.Day03Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day03",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day03:day03",
     ],
-    data = ["//inputs:2016/03"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day04/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day04/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day04.Day04Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day04:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day04:day04",
-    ],
     data = ["//inputs:2016/04"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day04:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day04.Day04Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day04",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day05/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day05/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/05"],
     test_class = "com.github.saser.adventofcode.year2016.day05.Day05Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day05",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day05:day05",
     ],
-    data = ["//inputs:2016/05"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day06/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day06/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/06"],
     resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day06:testdata"],
     test_class = "com.github.saser.adventofcode.year2016.day06.Day06Test",
     deps = [
@@ -8,5 +11,4 @@ java_test(
         "//java/src/main/java/com/github/saser/adventofcode/year2016/day06",
         "@maven//:junit_junit",
     ],
-    data = ["//inputs:2016/06"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day07/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day07/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day07.Day07Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day07:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day07:day07",
-    ],
     data = ["//inputs:2016/07"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day07:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day07.Day07Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day07",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day08/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day08/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day08.Day08Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day08:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day08:day08",
-    ],
     data = ["//inputs:2016/08"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day08:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day08.Day08Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day08",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day09/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day09/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/09"],
     test_class = "com.github.saser.adventofcode.year2016.day09.Day09Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day09",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day09:day09",
     ],
-    data = ["//inputs:2016/09"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day10/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day10/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/10"],
     test_class = "com.github.saser.adventofcode.year2016.day10.Day10Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day10",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day10:day10",
     ],
-    data = ["//inputs:2016/10"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day11/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day11/BUILD.bazel
@@ -1,6 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/11"],
     resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day11:testdata"],
     test_class = "com.github.saser.adventofcode.year2016.day11.Day11Test",
     deps = [
@@ -8,5 +11,4 @@ java_test(
         "//java/src/main/java/com/github/saser/adventofcode/year2016/day11",
         "@maven//:junit_junit",
     ],
-    data = ["//inputs:2016/11"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day12/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day12/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/12"],
     test_class = "com.github.saser.adventofcode.year2016.day12.Day12Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day12",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day12:day12",
     ],
-    data = ["//inputs:2016/12"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day13/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day13/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/13"],
     test_class = "com.github.saser.adventofcode.year2016.day13.Day13Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day13",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day13:day13",
     ],
-    data = ["//inputs:2016/13"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day14/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day14/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/14"],
     test_class = "com.github.saser.adventofcode.year2016.day14.Day14Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day14",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day14:day14",
     ],
-    data = ["//inputs:2016/14"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day15/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day15/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day15.Day15Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day15:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day15:day15",
-    ],
     data = ["//inputs:2016/15"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day15:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day15.Day15Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day15",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day16/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day16/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/16"],
     test_class = "com.github.saser.adventofcode.year2016.day16.Day16Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day16",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day16:day16",
     ],
-    data = ["//inputs:2016/16"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day17/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day17/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/17"],
     test_class = "com.github.saser.adventofcode.year2016.day17.Day17Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day17",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day17:day17",
     ],
-    data = ["//inputs:2016/17"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day18/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day18/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/18"],
     test_class = "com.github.saser.adventofcode.year2016.day18.Day18Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day18",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day18:day18",
     ],
-    data = ["//inputs:2016/18"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day19/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day19/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/19"],
     test_class = "com.github.saser.adventofcode.year2016.day19.Day19Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day19",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day19:day19",
     ],
-    data = ["//inputs:2016/19"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day20/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day20/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day20.Day20Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day20:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day20:day20",
-    ],
     data = ["//inputs:2016/20"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day20:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day20.Day20Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day20",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day21/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day21/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/21"],
     test_class = "com.github.saser.adventofcode.year2016.day21.Day21Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day21",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day21:day21",
     ],
-    data = ["//inputs:2016/21"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day22/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day22/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day22.Day22Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day22:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day22:day22",
-    ],
     data = ["//inputs:2016/22"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day22:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day22.Day22Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day22",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day23/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day23/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/23"],
     test_class = "com.github.saser.adventofcode.year2016.day23.Day23Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day23",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day23:day23",
     ],
-    data = ["//inputs:2016/23"],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day24/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day24/BUILD.bazel
@@ -1,12 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
-    test_class = "com.github.saser.adventofcode.year2016.day24.Day24Test",
-    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day24:testdata"],
-    deps = [
-        "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day24:day24",
-    ],
     data = ["//inputs:2016/24"],
+    resources = ["//java/src/test/resources/com/github/saser/adventofcode/year2016/day24:testdata"],
+    test_class = "com.github.saser.adventofcode.year2016.day24.Day24Test",
+    deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day24",
+        "@maven//:junit_junit",
+    ],
 )

--- a/java/src/test/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
+++ b/java/src/test/java/com/github/saser/adventofcode/year2016/day25/BUILD.bazel
@@ -1,11 +1,13 @@
+load("@rules_java//java:defs.bzl", "java_test")
+
 java_test(
     name = "test",
     srcs = glob(["*.java"]),
+    data = ["//inputs:2016/25"],
     test_class = "com.github.saser.adventofcode.year2016.day25.Day25Test",
     deps = [
+        "//java/src/main/java/com/github/saser/adventofcode",
+        "//java/src/main/java/com/github/saser/adventofcode/year2016/day25",
         "@maven//:junit_junit",
-        "//java/src/main/java/com/github/saser/adventofcode:adventofcode",
-        "//java/src/main/java/com/github/saser/adventofcode/year2016/day25:day25",
     ],
-    data = ["//inputs:2016/25"],
 )


### PR DESCRIPTION
Apparently, I had been formatting my BUILD files wrong for the longest time, so I am happy that this tool exists. Also, I am a little wary of the `@rules_cc`/`@rules_java` stuff -- they appear to be referencing external repositories, and I have no such repositories in my WORKSPACE file, but the build seems to work anyway. Furthermore, the
corresponding GitHub repositories (https://github.com/bazelbuild/rules_cc and
https://github.com/bazelbuild/rules_java) seem half abandoned, and the `rules_cc` README even states that there is no need to use those rules yet. Oh well, as long as the build works, I am happy.