### PR TITLE
java: remove unnecessary `TearDown` import

### DIFF
--- a/aocgen/templates/java/src/benchmark/java/com/github/saser/adventofcode/yearYYYY/dayDD/DayDDBenchmark.java
+++ b/aocgen/templates/java/src/benchmark/java/com/github/saser/adventofcode/yearYYYY/dayDD/DayDDBenchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day01/Day01Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day01/Day01Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day02/Day02Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day02/Day02Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day03/Day03Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day03/Day03Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day04/Day04Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day04/Day04Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day05/Day05Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day05/Day05Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day06/Day06Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day06/Day06Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day07/Day07Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day07/Day07Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day08/Day08Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day08/Day08Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day09/Day09Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day09/Day09Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day10/Day10Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day10/Day10Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day11/Day11Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day11/Day11Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day12/Day12Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day12/Day12Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day13/Day13Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day13/Day13Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day14/Day14Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day14/Day14Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day15/Day15Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day15/Day15Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day16/Day16Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day16/Day16Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day17/Day17Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day17/Day17Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day18/Day18Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day18/Day18Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day19/Day19Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day19/Day19Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day20/Day20Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day20/Day20Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day21/Day21Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day21/Day21Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day22/Day22Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day22/Day22Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day23/Day23Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day23/Day23Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day24/Day24Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day24/Day24Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)

--- a/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/Day25Benchmark.java
+++ b/java/src/benchmark/java/com/github/saser/adventofcode/year2016/day25/Day25Benchmark.java
@@ -16,7 +16,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
 @BenchmarkMode(Mode.AverageTime)


### PR DESCRIPTION
These are here because I added it at some point when creating the templates, but then I forgot to remove them again.