### PR TITLE
aocgen/templates: add template for Rust solutions

### DIFF
--- a/aocgen/templates/rust/src/yearYYYY/dayDD.rs
+++ b/aocgen/templates/rust/src/yearYYYY/dayDD.rs
@@ -1,0 +1,35 @@
+use std::io;
+
+use crate::base::Part;
+
+pub fn part1(r: &mut dyn io::Read) -> Result<String, String> {
+    solve(r, Part::One)
+}
+
+pub fn part2(r: &mut dyn io::Read) -> Result<String, String> {
+    solve(r, Part::Two)
+}
+
+fn solve(r: &mut dyn io::Read, part: Part) -> Result<String, String> {
+    Err("not implemented yet".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test;
+
+    mod part1 {
+        use super::*;
+
+        test!(example, "", "", part1);
+        test!(actual, file "../../../inputs/{{.Year}}/{{.PaddedDay}}", "", part1);
+    }
+
+    // mod part2 {
+    //     use super::*;
+
+    //     test!(example, "", "", part2);
+    //     test!(actual, file "../../../inputs/{{.Year}}/{{.PaddedDay}}", "", part2);
+    // }
+}

--- a/aocgen/templates/rust/src/yearYYYY/mod.rs
+++ b/aocgen/templates/rust/src/yearYYYY/mod.rs
@@ -1,0 +1,6 @@
+// NOTE: this has overwritten the previous `mod.rs`. If this is not what you
+// want, simply add `pub mod {{.FullDay}};` at the end of the current `mod.rs`.
+// Also: remember to add `pub mod {{.FullYear}}` to `src/lib.rs` for `cargo` to
+// actually pick up the `{{.FullYear}}` module as well as the `{{.FullDay}}`
+// module.
+pub mod {{.FullDay}};


### PR DESCRIPTION
In order to achieve a better "generate and immediately be able to run tests" experience, the `mod.rs` file for each year is always generated, and will most likely overwrite the existing `mod.rs` file. I therefore added a little comment that should make you aware that the file has been overwritten.